### PR TITLE
reset blend mode after drawing mesh

### DIFF
--- a/src/imgui_impl.cpp
+++ b/src/imgui_impl.cpp
@@ -99,6 +99,7 @@ void ImGui_Impl_RenderDrawLists(ImDrawData* draw_data)
 				love.graphics.setScissor(imgui.clipX, imgui.clipY, imgui.clipWidth, imgui.clipHeight) \
 				imgui.renderMesh:setDrawRange(imgui.vertexPosition, imgui.vertexCount) \
 				love.graphics.draw(imgui.renderMesh) \
+				love.graphics.setBlendMode(\"alpha\", \"alphamultiply\")\
 			");
 		}
 	}


### PR DESCRIPTION
When drawing a canvas the alpha blend mode is set to `premultiplied` but is not switched back if the final mesh texture is a canvas. This causes some inconsistent behaviour that is easily fixed by resetting the blend mode after each draw.