### PR TITLE
Fix saving and loading settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ imgui.Begin("Test Window", true, "ImGuiWindowFlags_AlwaysAutoResize");
 
 It uses imgui 1.73 and is based on LÖVE 11.1.
 
-## Getting Started
+## Getting Started 
 
 Build the project using CMake:
 

--- a/src/imgui_impl.cpp
+++ b/src/imgui_impl.cpp
@@ -199,15 +199,16 @@ bool Init(lua_State *L)
 
 	io.Fonts->TexID = NULL;
 
-	luaL_dostring(L, "love.filesystem.createDirectory('/') return love.filesystem.getSaveDirectory()");
-	const char *path = luaL_checkstring(L, 1);
-	g_iniPath = std::string(path) + std::string("/imgui.ini");
-	io.IniFilename = g_iniPath.c_str();
+	io.IniFilename = NULL;
+	g_iniPath = std::string("imgui.ini");
+	ImGui::LoadIniSettingsFromDisk(g_iniPath.c_str());
+
 	return true;
 }
 
 void ShutDown()
 {
+	ImGui::SaveIniSettingsToDisk(g_iniPath.c_str());
 	ImGui::DestroyContext();
 }
 


### PR DESCRIPTION
Imgui doesn't seem to be able to save the settings to the save directory. 
This PR it a crude fix to manually load in Init and save in Shutdown.
This saves to the folder next to main.lua, instead of in the save directory.