### PR TITLE
Fix ImGui_Impl_GetClipboardText

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,4 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 3.0)
-
 IF(${CMAKE_CURRENT_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_BINARY_DIR})
 	# Protip: run cmake like this: cmake -Bbuild -H. or see the readme
 	message(FATAL_ERROR "Prevented in-tree build.")
@@ -45,7 +44,8 @@ TARGET_INCLUDE_DIRECTORIES(love-imgui PUBLIC
 IF(WIN32 OR ANDROID OR IOS)
 	TARGET_LINK_LIBRARIES(love-imgui ${DESIRED_LUA_LIBRARY})
 ELSEIF(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
-	TARGET_COMPILE_DEFINITIONS(love-imgui -undefined dynamic_lookup)
+	# TARGET_COMPILE_DEFINITIONS(love-imgui -undefined dynamic_lookup)
+	TARGET_LINK_LIBRARIES(love-imgui ${DESIRED_LUA_LIBRARY})
 ENDIF()
 
 SET_TARGET_PROPERTIES(love-imgui PROPERTIES PREFIX "" OUTPUT_NAME "imgui")

--- a/src/imgui_impl.cpp
+++ b/src/imgui_impl.cpp
@@ -110,7 +110,7 @@ void ImGui_Impl_RenderDrawLists(ImDrawData* draw_data)
 static const char* ImGui_Impl_GetClipboardText(void* user_data)
 {
 	luaL_dostring(g_L, "return love.system.getClipboardText()");
-	return luaL_checkstring(g_L, 0);
+	return luaL_checkstring(g_L, -1);
 }
 
 static void ImGui_Impl_SetClipboardText(void* user_data, const char* text)


### PR DESCRIPTION
Previously, pasting in an imgui text field and using `imgui.GetClipboardText()` produced garbage values. I've also included a very minimal program that reproduces the error.

Before this fix:
![image](https://github.com/MikuAuahDark/love-imgui/assets/10176105/76639f24-596c-47a2-833a-05a1c8357dac)

After this fix:
![image](https://github.com/MikuAuahDark/love-imgui/assets/10176105/498be62a-87a8-4ddb-9c53-6779c67b7cb3)

[loveimguicopypastetest.zip](https://github.com/MikuAuahDark/love-imgui/files/15205102/loveimguicopypastetest.zip)
