### PR TITLE
Fix mouse hiding behavior

### DIFF
--- a/src/imgui_impl.cpp
+++ b/src/imgui_impl.cpp
@@ -243,7 +243,7 @@ void NewFrame()
 	DoStringCache::getImgui(g_L);
 	lua_pushboolean(g_L, (int)io.MouseDrawCursor);
 	lua_setfield(g_L, -2, "mouseDrawCursor");
-	luaL_dostring(g_L, "love.mouse.setVisible(not imgui.mouseDrawCursor)");
+	luaL_dostring(g_L, "love.mouse.setVisible((not imgui.mouseDrawCursor) and love.mouse.isVisible())");
 
 	// Init lua data
 	luaL_dostring(g_L, "imgui.textures = nil");


### PR DESCRIPTION
The mouse no longer re-shows if the user has called love.mouse.setVisible(false) on their own.